### PR TITLE
Improve performance of the sqlelf command

### DIFF
--- a/sqlelf/elf/dynamic.py
+++ b/sqlelf/elf/dynamic.py
@@ -13,8 +13,11 @@ import lief
 def elf_dynamic_entries(binaries: list[lief.Binary]):
     def generator() -> Iterator[dict[str, Any]]:
         for binary in binaries:
+            # super important that these accessors are pulled out of the tight loop
+            # as they can be costly
+            binary_name = binary.name
             for entry in binary.dynamic_entries:
-                yield {"path": binary.name, "tag": entry.tag.name, "value": entry.value}
+                yield {"path": binary_name, "tag": entry.tag.name, "value": entry.value}
 
     return generator
 

--- a/sqlelf/elf/section.py
+++ b/sqlelf/elf/section.py
@@ -11,9 +11,12 @@ import lief
 def elf_sections(binaries: list[lief.Binary]):
     def generator() -> Iterator[dict[str, Any]]:
         for binary in binaries:
+            # super important that these accessors are pulled out of the tight loop
+            # as they can be costly
+            binary_name = binary.name
             for section in binary.sections:
                 yield {
-                    "path": binary.name,
+                    "path": binary_name,
                     "name": section.name,
                     "offset": section.offset,
                     "size": section.size,

--- a/sqlelf/elf/strings.py
+++ b/sqlelf/elf/strings.py
@@ -16,13 +16,16 @@ def elf_strings(binaries: list[lief.Binary]):
                 for section in binary.sections
                 if section.type == lief.ELF.SECTION_TYPES.STRTAB
             ]
+            # super important that these accessors are pulled out of the tight loop
+            # as they can be costly
+            binary_name = binary.name
             for strtab in strtabs:
                 # The first byte is always the null byte in the STRTAB
                 # Python also treats the final null in the string by creating
                 # an empty item so we chop it off.
                 # https://stackoverflow.com/a/18970869
                 for string in str(strtab.content[1:-1], "utf-8").split("\x00"):
-                    yield {"path": binary.name, "section": strtab.name, "value": string}
+                    yield {"path": binary_name, "section": strtab.name, "value": string}
 
     return generator
 

--- a/sqlelf/elf/symbol.py
+++ b/sqlelf/elf/symbol.py
@@ -11,9 +11,12 @@ import lief
 def elf_symbols(binaries: list[lief.Binary]):
     def generator() -> Iterator[dict[str, Any]]:
         for binary in binaries:
+            # super important that these accessors are pulled out of the tight loop
+            # as they can be costly
+            binary_name = binary.name
             for symbol in binary.symbols:
                 yield {
-                    "path": binary.name,
+                    "path": binary_name,
                     "name": symbol.name,
                     "demangled_name": symbol.demangled_name,
                     # A bit of detailed explanation here to explain these values.


### PR DESCRIPTION
```
❯ time sqlelf /usr/bin/python3 --sql "select path, mnemonic, COUNT(*) from elf_instructions where section = '.text' GROUP BY path, mnemonic ORDER BY RANDOM() LIMIT 10"
/usr/bin/python3|setg|60
/usr/bin/python3|setle|53
/usr/bin/python3|jne|31583
/usr/bin/python3|por|58
/usr/bin/python3|cmovbe|22
/usr/bin/python3|pshufd|82
/usr/bin/python3|rep stosq|9
/usr/bin/python3|cmovnp|2
/usr/bin/python3|movd|901
/usr/bin/python3|pop|22305
sqlelf /usr/bin/python3 --sql   5.43s user 0.16s system 99% cpu 5.600 total
```

The command above wouldn't even finish in 10 minutes before but now completes in something semi-reasonable (~5s).

Tom gave me the insight to use py-spy to generate some performance viz using speedscope:
```
> py-spy record -o profile.prof -f speedscope -- $(which sqlelf) /usr/bin/python3 --sql "select COUNT(*) from elf_instructions where section = '.text'"
```

That gave me the hint that the problem is probably in the actual creation of the hash map itself.

TY @trws