### PR TITLE
Create temporary tables to improve performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,7 @@ fmt:              ## Format code using black & isort.
 lint:             ## Run pep8, black, mypy linters.
 	flake8 sqlelf/
 	black --check sqlelf/
-	pyright
+# TODO(fzakaria): without pythonpath it picks up the wrong python
+# and then does not find the venv for the imports
+	pyright --pythonpath $(shell which python)
 	nixpkgs-fmt --check .

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,6 @@
         };
 
         devShell = pkgs.sqlelf-env.env.overrideAttrs
-          (oldAttrs: { buildInputs = with pkgs; [ poetry pyright nixpkgs-fmt ]; });
+          (oldAttrs: { buildInputs = with pkgs; [ poetry nixpkgs-fmt ]; });
       });
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -260,6 +260,21 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.8.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
@@ -324,6 +339,25 @@ files = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.325"
+description = "Command line wrapper for pyright"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyright-1.1.325-py3-none-any.whl", hash = "sha256:8f3ab88ba4843f053ab5b5c886d676161aba6f446776bfb57cc0434ed4d88672"},
+    {file = "pyright-1.1.325.tar.gz", hash = "sha256:879a3f66944ffd59d3facd54872fed814830fed64daf3e8eb71b146ddd83bb67"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+
+[[package]]
 name = "setuptools"
 version = "68.1.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -355,4 +389,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10"
-content-hash = "0871b2e72bc3a35e481b388aaccd898b4225a2f5ab3368770188a2411cfab7de"
+content-hash = "838653258e74177629af577ca8ec4cebaa7b06ab0fac57c0cce39c2319db4bbd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ setuptools = "*"
 black = "^23.7.0"
 isort = "^5.12.0"
 flake8 = "^6.1.0"
+pyright = "^1.1.325"
 
 [build-system]
 requires = ["poetry-core"]

--- a/sqlelf/elf/instruction.py
+++ b/sqlelf/elf/instruction.py
@@ -63,4 +63,10 @@ def register(connection: apsw.Connection, binaries: list[lief.Binary]):
     generator.columns, generator.column_access = apsw.ext.get_column_names(
         next(generator())
     )
-    apsw.ext.make_virtual_module(connection, "elf_instructions", generator)
+    apsw.ext.make_virtual_module(connection, "raw_elf_instructions", generator)
+    connection.execute(
+        """
+        CREATE TEMP TABLE elf_instructions
+        AS SELECT * FROM raw_elf_instructions;
+        """
+    )

--- a/sqlelf/elf/section.py
+++ b/sqlelf/elf/section.py
@@ -27,6 +27,12 @@ def elf_sections(binaries: list[lief.Binary]):
     return generator
 
 
+def section_name(name: str | None) -> str | None:
+    if name == "":
+        return "undefined"
+    return name
+
+
 def register(connection: apsw.Connection, binaries: list[lief.Binary]):
     generator = elf_sections(binaries)
     # setup columns and access by providing an example of the first entry returned


### PR DESCRIPTION
Create temporary tables for symbols and instructions to improve performance.

There is an upfront cost to ingesting the data into a temporary table but it's relatively nominal (2s) and every query is WAY faster afterwards.

Also moved pyright to a poetry dependency.

TY for help and advice from @rogerbinns