### PR TITLE
Add support for `--recursive`

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -17,6 +17,9 @@ self: super: {
   });
 
   poetryOverrides = self: super: {
+    sh = super.sh.overridePythonAttrs (old: {
+      buildInputs = (old.buildInputs or [ ]) ++ [ super.poetry ];
+    });
     apsw = super.apsw.overridePythonAttrs (old: rec {
       version = "3.43.0.0";
       src = super.pkgs.fetchFromGitHub {

--- a/poetry.lock
+++ b/poetry.lock
@@ -441,6 +441,18 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[l
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
+name = "sh"
+version = "2.0.6"
+description = "Python subprocess replacement"
+category = "main"
+optional = false
+python-versions = ">=3.8.1,<4.0"
+files = [
+    {file = "sh-2.0.6-py3-none-any.whl", hash = "sha256:ced8f2e081a858b66a46ace3703dec243779abbd5a1887ba7e3c34f34da70cd2"},
+    {file = "sh-2.0.6.tar.gz", hash = "sha256:9b2998f313f201c777e2c0061f0b1367497097ef13388595be147e2a00bf7ba1"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -454,5 +466,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.10"
-content-hash = "89fac12455f97e1a220b2f47c76549829e90082685010ad7e8af9e33f052a2ea"
+python-versions = ">=3.10,<4.0"
+content-hash = "9db545297dad604636c6b2de79f3b5a8bc5072ee8a2df2a75aa731ed5de9fb87"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ description = "Explore ELF objects through the power of SQL"
 license = "LICENSE"
 
 [tool.poetry.dependencies]
-python = ">=3.10"
+python = ">=3.10,<4.0"
 capstone = "^5.0.1"
 lief = "^0.13.2"
 apsw = "^3.43.0.0"
@@ -16,6 +16,7 @@ apsw = "^3.43.0.0"
 # ERROR: Could not find a version that satisfies the requirement setuptools<61.0.0,>=60.0.0 (from sqlelf) (from versions: none)
 # ERROR: No matching distribution found for setuptools<61.0.0,>=60.0.0
 setuptools = "*"
+sh = "^2.0.6"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.7.0"

--- a/sqlelf/elf/instruction.py
+++ b/sqlelf/elf/instruction.py
@@ -7,8 +7,7 @@ import apsw
 import apsw.ext
 
 # TODO(fzkakaria): https://github.com/capstone-engine/capstone/issues/1993
-# pyright: reportMissingTypeStubs=false
-import capstone
+import capstone  # pyright: ignore
 import lief
 
 

--- a/sqlelf/ldd.py
+++ b/sqlelf/ldd.py
@@ -1,0 +1,23 @@
+import re
+from collections import OrderedDict
+from typing import Dict
+
+import lief
+from sh import Command  # pyright: ignore
+
+
+def libraries(binary: lief.Binary) -> Dict[str, str]:
+    """Use the interpreter in a binary to determine the path of each linked library"""
+    interpreter = Command(binary.interpreter)  # pyright: ignore
+    resolution = interpreter("--list", binary.name)
+    result = OrderedDict()
+    # TODO: Figure out why `--list` and `ldd` produce different outcomes
+    # specifically for the interpreter.
+    # https://gist.github.com/fzakaria/3dc42a039401598d8e0fdbc57f5e7eae
+    for line in resolution.splitlines():  # pyright: ignore
+        m = re.match(r"\s*([^ ]+) => ([^ ]+)", line)
+        if not m:
+            continue
+        soname, lib = m.group(1), m.group(2)
+        result[soname] = lib
+    return result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,9 @@ def test_cli_single_file_arguments():
     stdin = StringIO("")
     cli.start(["/bin/ls"], stdin)
 
+def test_cli_single_non_existent_file_arguments():
+    cli.start(["does_not_exist"])
+
 def test_cli_prompt_single_file_arguments():
     stdin = StringIO(".exit 56\n")
     with pytest.raises(SystemExit) as err:

--- a/tests/test_ldd.py
+++ b/tests/test_ldd.py
@@ -1,0 +1,8 @@
+from sqlelf import ldd
+import lief
+
+def test_simple_binary():
+    binary = lief.parse("/bin/ls")
+    result = ldd.libraries(binary)
+    print(result)
+    assert len(result) > 0


### PR DESCRIPTION
Add support for loading recursively all shared libraries by a library.
This is useful if you want to inspect symbol resolution for instance.

* add pytest
* added some simple unit tests as scaffolding
* updated the README