### PR TITLE
Only iterate static or dynamic symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ sqlelf.egg-info/
 .vscode/
 dist/
 result
+examples/shadowed-symbols/exe
+examples/**/*.so

--- a/examples/shadowed-symbols/Makefile
+++ b/examples/shadowed-symbols/Makefile
@@ -1,0 +1,25 @@
+all: exe
+
+# This library depends libx2.so soname and calls h() from it
+y/liby.so: x/libx2.so
+	@mkdir -p $(dir $@)
+	echo 'extern int foo(); int g() { return foo(); }' | $(CC) -o $@ -shared -x c - -Lx -l:libx2.so '-Wl,--no-as-needed,--enable-new-dtags,-rpath,$$ORIGIN/../x'
+
+# This library has both file and soname libx.so
+x/libx.so:
+	@mkdir -p $(dir $@)
+	echo 'int foo(){return 12;}' | $(CC) -o $@ -shared -x c -
+
+# This library has both file and soname libx.so
+x/libx2.so:
+	@mkdir -p $(dir $@)
+	echo 'int foo(){return 1000;}' | $(CC) -o $@ -shared -x c -
+
+# This links to b/liby.so and c/libx.so, and gets libx.so and liby.so in DT_NEEDED, no paths.
+exe: y/liby.so x/libx.so
+	echo 'extern int g(); extern int foo(); int main(){ printf("\%d\n", g() + foo()); }' | \
+	$(CC) -o $@ -include stdio.h -x c - -Ly -Lx -l:liby.so '-Wl,--no-as-needed,--enable-new-dtags,-rpath,$$ORIGIN/y' \
+		  -l:libx.so '-Wl,--no-as-needed,--enable-new-dtags,-rpath,$$ORIGIN/x'
+
+clean:
+	rm -rf -- x y exe

--- a/sqlelf/cli.py
+++ b/sqlelf/cli.py
@@ -60,7 +60,7 @@ def start(args=sys.argv[1:], stdin=sys.stdin):
 
     # If none of the inputs are valid files, simply return
     if len(filenames) == 0:
-        return
+        sys.exit("No valid ELF files were provided")
 
     binaries: list[Binary] = [Binary(filename) for filename in filenames]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,8 @@ def test_cli_single_file_arguments():
     cli.start(["/bin/ls"], stdin)
 
 def test_cli_single_non_existent_file_arguments():
-    cli.start(["does_not_exist"])
+    with pytest.raises(SystemExit) as err:
+        cli.start(["does_not_exist"])
 
 def test_cli_prompt_single_file_arguments():
     stdin = StringIO(".exit 56\n")


### PR DESCRIPTION
As a response to https://github.com/lief-project/LIEF/issues/962 only iterate static or dynamic symbols.

Added a simple Makefile to demonstrate shadowing variables.