### PR TITLE
Add Version requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,7 @@ lint:             ## Run pep8, black, mypy linters.
 .PHONY: test
 test:             ## Run pytest primarily.
 	pytest
+
+.PHONY: coverage
+coverage:
+	coverage run -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pyright >= 1.1.325",
     "pytest >= 7.4.0",
     "mypy >= 1.0.0",
+    "coverage[toml] >= 7.3",
 ]
 
 [tool.setuptools_scm]
@@ -69,3 +70,7 @@ useLibraryCodeForTypes = true
 pythonVersion = "3.10"
 pythonPlatform = "Linux"
 include = ["sqlelf", "tests"]
+
+[tool.coverage.run]
+omit = ["sqlelf/_version.py", "sqlelf/**/__init__.py", "tests/**/__init__.py"]
+branch = true

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -40,6 +40,7 @@ def test_simple_binary_mocked(Command: sh.Command) -> None:
 
 
 def test_simple_select_header() -> None:
+    # TODO(fzakaria): Figure out a better binary to be doing that we control
     engine = sql.make_sql_engine([lief.parse("/bin/ls")])
     result = list(engine.execute("SELECT * FROM elf_headers LIMIT 1"))
     assert len(result) == 1
@@ -48,3 +49,13 @@ def test_simple_select_header() -> None:
     assert "version" in result[0]
     assert "machine" in result[0]
     assert "entry" in result[0]
+
+
+def test_simple_select_version_requirements() -> None:
+    # TODO(fzakaria): Figure out a better binary to be doing that we control
+    engine = sql.make_sql_engine([lief.parse("/bin/ls")])
+    result = list(engine.execute("SELECT * FROM elf_version_requirements LIMIT 1"))
+    assert len(result) == 1
+    assert "path" in result[0]
+    assert "file" in result[0]
+    assert "name" in result[0]


### PR DESCRIPTION
Add the equivalent to '.gnu.version_r' to the SQL schema.
This is to fetch version requirements for the symbols per library from DT_NEEDED.