### PR TITLE
Make the tables that are registered configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ lint:             ## Run pep8, black, mypy linters.
 .PHONY: test
 test:             ## Run pytest primarily.
 	pytest
+	pytest -m "slow"
 
 .PHONY: coverage
 coverage:

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ WHERE elf_dynamic_entries.tag = 'NEEDED'"
 
 <details>
 <summary>Determine the RPATH/RINPATH entries for a program</summary>
+
 _This may be improved in the future but for now there is a little knowledge of the
 polymorphic nature of the dynamic entries needed_.
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,34 @@ WHERE elf_dynamic_entries.tag = 'NEEDED'"
 ```
 </details>
 
+<details>
+<summary>Determine the RPATH/RINPATH entries for a program</summary>
+_This may be improved in the future but for now there is a little knowledge of the
+polymorphic nature of the dynamic entries needed_.
+
+The below uses a file built with [NixOS](https://nixos.org) as they all have RUNPATH set.
+
+A recursive query can further be used to split the row into multiple rows. 
+
+```console
+❯ sqlelf /nix/store/gjr9ylm023rl9di484g1wxcd1jp84xxv-nix-2.8.1/bin/nix \
+ --sql "SELECT elf_strings.path, elf_strings.value
+FROM elf_dynamic_entries
+INNER JOIN elf_strings ON elf_dynamic_entries.value = elf_strings.offset
+WHERE elf_dynamic_entries.tag = 'RUNPATH';"
+┌─────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                      path                       │                                                                                 value                                                                                 │
+├─────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ /nix/store/gjr9ylm023rl9di484g1wxcd1jp84xxv-    │ /nix/store/gjr9ylm023rl9di484g1wxcd1jp84xxv-                                                                                                                          │
+│ nix-2.8.1/bin/nix                               │ nix-2.8.1/lib:/nix/store/pkxyfwarcq081rybpbnprjmnkiy1cz6g-libsodium-1.0.18/lib:/nix/store/r6mrf9pz4dpax6rcszcmbyrpsk8j6saz-                                           │
+│                                                 │ editline-1.17.1/lib:/nix/store/ppm63lvkyfa58sgcnr2ddzh14dy1k9fn-boehm-gc-8.0.6/lib:/nix/store/sgw2i15l01rwxzj62745h30bsjmh7wc1-lowdown-0.11.1-                        │
+│                                                 │ lib/lib:/nix/store/bvy2z17rzlvkx2sj7fy99ajm853yv898-glibc-2.34-210/lib:/nix/store/gka59hya7l7qp26s0rydcgq8hj0d7v7k-gcc-11.3.0-lib/lib                                 │
+└─────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+</details>
+
+
 ## Development
 
 You may want to install the package in _editable mode_ as well to make development easier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ skip = [".git", "result"]
 profile = "black"
 
 [tool.pytest.ini_options]
-addopts = ""
+addopts = "-m 'not slow' --strict-markers"
+markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 
 [tool.pyright]
 exclude = ["**/__pycache__", "sqlelf/_version.py"]

--- a/sqlelf/sql.py
+++ b/sqlelf/sql.py
@@ -59,13 +59,23 @@ def find_libraries(binary: lief.Binary) -> Dict[str, str]:
     return result
 
 
-def make_sql_engine(filenames: list[str], recursive: bool = False) -> SQLEngine:
+def make_sql_engine(
+    filenames: list[str],
+    recursive: bool = False,
+    flags: elf.GeneratorFlag = elf.GeneratorFlag.ALL(),
+) -> SQLEngine:
     """Create a SQL engine from a list of binaries
+
+    You can make the SQL engine more speedy by only specifying the
+    Generators (virtual tables) that you care about via the flags argument.
+    The INSTRUCTIONS and SYMBOLS table are typically quite expensive to generate
+    if they are not
 
     Args:
         filenames: the list of binaries to analyze -- should be absolute path
         recursive: whether to recursively load all shared
                 libraries needed by each binary
+        flags: the flags to use when generating the virtual tables
     """
     binaries: list[lief.Binary] = [
         lief.parse(filename) for filename in filenames if lief.is_elf(filename)
@@ -88,5 +98,5 @@ def make_sql_engine(filenames: list[str], recursive: bool = False) -> SQLEngine:
         )
         binaries = binaries + [lief.parse(library) for library in shared_libraries_set]
 
-    elf.register_virtual_tables(connection, binaries)
+    elf.register_virtual_tables(connection, binaries, flags)
     return SQLEngine(connection)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,31 @@
+"""This file tests the examples in the README.md file"""
+
+from sqlelf import sql, elf
+import pytest
+
+
+@pytest.mark.slow
+def test_symbol_resolutions() -> None:
+    # TODO(fzakaria): Make sure this binary
+    # is always present in the CI environment.
+    sql_engine = sql.make_sql_engine(
+        ["/usr/bin/ruby"], recursive=True, flags=elf.GeneratorFlag.SYMBOLS
+    )
+    result = sql_engine.execute(
+        """
+                        SELECT caller.path as 'caller.path',
+                            callee.path as 'calee.path',
+                            caller.name,
+                            caller.demangled_name
+                        FROM ELF_SYMBOLS caller
+                        INNER JOIN ELF_SYMBOLS callee
+                        ON
+                        caller.name = callee.name AND
+                        caller.path != callee.path AND
+                        caller.imported = TRUE AND
+                        callee.exported = TRUE
+                        LIMIT 25
+                       """
+    )
+    rows = list(result)
+    assert len(rows) == 25


### PR DESCRIPTION
Make the list of tables configurable in the API.
Some of the tables are quite expensive to generate such a instructions or symbols.

Allow the users to configure which tables to generate when they create a sql_engine.

CC @markrwilliams