### PR TITLE
Allow to query RISC-V ELF binaries

### DIFF
--- a/examples/hello-riscv/README.md
+++ b/examples/hello-riscv/README.md
@@ -1,0 +1,57 @@
+# Hello World in RISC-V
+
+This example shows how to assemble, link and query a simple Hello World program for RISC-V.
+
+If you want to run this example, you will need a cross-compiling toolchain like the [RISC-V GNU Compiler Toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain) and [QEMU](https://www.qemu.org/).
+
+## 32-bit
+
+Assemble `hello.s` into an object file for the RISC-V 32-bit base integer instruction set (`-march rv32i`), little-endian (`-mlittle-endian`), with an ABI that follows the convention where `int`, `long` and `pointer` types are all 32-bit, with debug symbols included in the object file (`-g`):
+
+```sh
+riscv64-elf-as -march rv32i -mabi ilp32 -mlittle-endian -o hello.o hello.s -g
+```
+
+Link the object file into a RISC-V 32-bit little-endian executable (`-m elf32lriscv`), with the symbol `_start` as its entry point:
+
+```sh
+riscv64-elf-ld -e _start -m elf32lriscv -o exe --verbose hello.o
+```
+
+Execute the RISC-V ELF in QEMU:
+
+```sh
+qemu-riscv32 exe
+```
+
+Double check the disassembly:
+
+```sh
+riscv64-elf-objdump --disassemble exe
+```
+
+## 64-bit
+
+Assemble `hello.s` into an object file for the RISC-V 64-bit base integer instruction set (`-march rv64i`), little-endian (`-mlittle-endian`), with an ABI that follows the convention where `long` and `pointer` types are all 64-bit, with debug symbols included in the object file (`-g`):
+
+```sh
+riscv64-elf-as -march rv64i -mabi lp64 -mlittle-endian -o hello.o hello.s -g
+```
+
+Link the object file into a RISC-V 64-bit little-endian executable (`-m elf64lriscv`), with the symbol `_start` as its entry point:
+
+```sh
+riscv64-elf-ld -e _start -m elf64lriscv -o exe --verbose hello.o
+```
+
+Execute the RISC-V ELF in QEMU:
+
+```sh
+qemu-riscv64 exe
+```
+
+Double check the disassembly:
+
+```sh
+riscv64-elf-objdump --disassemble exe
+```

--- a/examples/hello-riscv/hello.s
+++ b/examples/hello-riscv/hello.s
@@ -1,0 +1,41 @@
+.section .text
+.globl _start
+.equ STDOUT, 1 # File descriptor 1 is standard output (stdout)
+.equ WRITE, 64 # Linux write syscall
+.equ EXIT, 93 # Linux exit syscall
+.equ EXIT_CODE_SUCCESS, 0
+  
+_start:
+    # In C, a list of parameters is passed to the kernel in a certain sequence.
+    # For the write system call, the parameters are structured as follows:
+    # ssize_t write(int fd, const void *buf, size_t count)
+    # The three parameters passed are:
+    # 1. a file descriptor (e.g. 1 for stdout)
+    # 2. a pointer to a character buffer (i.e. a string)
+    # 3. the number of characters in that string to be written. 
+    li a0, STDOUT
+    la a1, buf_begin
+    # Load a byte from memory, zero-pad it (to a 64-bit value in RV64), and store
+    # the unsigned value in the destination register a2.
+    lbu a2, buf_size
+    
+    # Store the system call number in register a7.
+    li a7, WRITE
+    # Switch to RISC-V supervisor mode (the Linux kernel runs in this mode) and
+    # make a request using the value stored in a7 as the system call number.
+    ecall
+
+    li a0, EXIT_CODE_SUCCESS
+    li a7, EXIT
+    ecall
+
+# The .rodata section of an ELF binary contains constant values. The .rodata
+# section is marked as read-only, so these values cannot change at runtime.
+.section .rodata
+
+buf_begin:
+    .string "Hello World!\n"
+buf_size:
+    # Current address (the .) minus address of buf_begin = length of buffer.
+    # We store the result in a 8-bit word using the .byte directive.
+    .byte .-buf_begin

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,8 @@
       with nixpkgsFor.${system}; {
         default = mkShellNoCC {
           venvDir = "./.venv";
+          # needed for tests
+          TEST_BINARY = "${coreutils}/bin/ls";
           packages = [
             python3Packages.pip
             # This execute some shell code to initialize a venv in $venvDir before

--- a/sqlelf/elf.py
+++ b/sqlelf/elf.py
@@ -227,6 +227,11 @@ def register_instructions_generator(
 def mode(binary: lief_ext.Binary) -> int:
     if (
         binary.header.machine_type == lief.ELF.ARCH.RISCV
+        and binary.header.identity_class == lief.ELF.ELF_CLASS.CLASS32
+    ):
+        return cast(int, capstone.CS_MODE_RISCV32)
+    if (
+        binary.header.machine_type == lief.ELF.ARCH.RISCV
         and binary.header.identity_class == lief.ELF.ELF_CLASS.CLASS64
     ):
         return cast(int, capstone.CS_MODE_RISCV64)

--- a/sqlelf/elf.py
+++ b/sqlelf/elf.py
@@ -225,18 +225,17 @@ def register_instructions_generator(
 
 
 def mode(binary: lief_ext.Binary) -> int:
-    if (
-        binary.header.machine_type == lief.ELF.ARCH.RISCV
-        and binary.header.identity_class == lief.ELF.ELF_CLASS.CLASS32
-    ):
-        return cast(int, capstone.CS_MODE_RISCV32)
-    if (
-        binary.header.machine_type == lief.ELF.ARCH.RISCV
-        and binary.header.identity_class == lief.ELF.ELF_CLASS.CLASS64
-    ):
-        return cast(int, capstone.CS_MODE_RISCV64)
-    if binary.header.identity_class == lief.ELF.ELF_CLASS.CLASS64:
-        return cast(int, capstone.CS_MODE_64)
+    machine_type = binary.header.machine_type
+    identity_class = binary.header.identity_class
+    if machine_type == lief.ELF.ARCH.RISCV:
+        if identity_class == lief.ELF.ELF_CLASS.CLASS32:
+            return cast(int, capstone.CS_MODE_RISCV32)
+    if machine_type == lief.ELF.ARCH.RISCV:
+        if identity_class == lief.ELF.ELF_CLASS.CLASS64:
+            return cast(int, capstone.CS_MODE_RISCV64)
+    if machine_type == lief.ELF.ARCH.x86_64:
+        if identity_class == lief.ELF.ELF_CLASS.CLASS64:
+            return cast(int, capstone.CS_MODE_64)
     raise RuntimeError(f"Unknown mode for {binary.path}")
 
 

--- a/sqlelf/elf.py
+++ b/sqlelf/elf.py
@@ -225,6 +225,11 @@ def register_instructions_generator(
 
 
 def mode(binary: lief_ext.Binary) -> int:
+    if (
+        binary.header.machine_type == lief.ELF.ARCH.RISCV
+        and binary.header.identity_class == lief.ELF.ELF_CLASS.CLASS64
+    ):
+        return cast(int, capstone.CS_MODE_RISCV64)
     if binary.header.identity_class == lief.ELF.ELF_CLASS.CLASS64:
         return cast(int, capstone.CS_MODE_64)
     raise RuntimeError(f"Unknown mode for {binary.path}")
@@ -233,6 +238,8 @@ def mode(binary: lief_ext.Binary) -> int:
 def arch(binary: lief_ext.Binary) -> int:
     if binary.header.machine_type == lief.ELF.ARCH.x86_64:
         return cast(int, capstone.CS_ARCH_X86)
+    elif binary.header.machine_type == lief.ELF.ARCH.RISCV:
+        return cast(int, capstone.CS_ARCH_RISCV)
     raise RuntimeError(f"Unknown machine type for {binary.path}")
 
 


### PR DESCRIPTION
This PR addresses #22 

RISC-V ELF binaries can now be analyzed like x86_64 ELF binaries.

## Examples

Select the first 5 instructions in the entire ELF.

```sh
sqlelf examples/hello-riscv/exe --sql "SELECT * FROM elf_instructions LIMIT 5;"
```

List the sections of an ELF file and sort them by binary size, in descending order.

```sh
sqlelf examples/hello-riscv/exe --sql "SELECT * FROM elf_sections ORDER BY size DESC"
```

Find the 10 largest unexported symbols of the `.bss` section by binary size.

```sh
sqlelf examples/hello-riscv/exe --sql \
"SELECT 
  name,
  section,
  size,
  type,
  value
FROM elf_symbols
WHERE exported = FALSE
ORDER BY size DESC
LIMIT 10;"
```