### PR TITLE
Fix pytest in derivation.nix

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -45,7 +45,7 @@ in
       [pytestCheckHook flake8 mypy isort black]
       ++ [pyright];
 
-    checkPhase = ''
+    postCheck = ''
       make lint
     '';
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ classifiers = [
 ]
 dependencies = [
     "capstone >= 5.0.1",
-    "lief >=0.14.1",
+    # lief has proven to change API a lot
+    # pin it to a specific version
+    "lief ==0.14.1",
     "apsw >= 3.43.1.0",
     "sh >= 2.0.6",
 ]


### PR DESCRIPTION
We were overriding checkPhase so the pytest hook would not run. Use postCheck instead which is a hook that is executed.